### PR TITLE
Move endpointNameAttribute

### DIFF
--- a/src/NServiceBus.Hosting.Tests/EndpointTypeTests.cs
+++ b/src/NServiceBus.Hosting.Tests/EndpointTypeTests.cs
@@ -50,6 +50,50 @@ namespace NServiceBus.Hosting.Tests
                 Assert.AreEqual("EndpointNameFromAttribute", endpointType.EndpointName);
             }
 
+            [EndpointName("EndpointNameFromAttribute")]
+            class TestEndpointTypeWithEndpointNameAttribute
+            {
+            }
+
+            [Test]
+            public void when_core_endpointName_attribute_exists_it_should_have_first_priority()
+            {
+                var hostArguments = new HostArguments(new string[0])
+                {
+                    EndpointName = "EndpointNameFromHostArgs"
+                };
+                var endpointType = new EndpointType(hostArguments, typeof(TestEndpointTypeWithCoreEndpointNameAttribute));
+
+                Assert.AreEqual("EndpointNameFromCoreAttribute", endpointType.EndpointName);
+            }
+
+            [NServiceBus.EndpointName("EndpointNameFromCoreAttribute")]
+            class TestEndpointTypeWithCoreEndpointNameAttribute
+            {
+            }
+
+            [Test]
+            public void when_both_core_and_host_endpointName_attribute_exists_it_should_throw()
+            {
+                var hostArguments = new HostArguments(new string[0])
+                                    {
+                                        EndpointName = "EndpointNameFromHostArgs"
+                                    };
+                var endpointType = new EndpointType(hostArguments, typeof(TestEndpointTypeWithBothEndpointNameAttribute));
+                var exception = Assert.Throws<Exception>(() =>
+                {
+                    // ReSharper disable once UnusedVariable
+                    var endpointName = endpointType.EndpointName;
+                });
+                Assert.AreEqual("Please either define a [NServiceBus.EndpointNameAttribute] or a [NServiceBus.Hosting.Windows.EndpointNameAttribute], but not both.", exception.Message);
+            }
+
+            [NServiceBus.EndpointName("EndpointNameFromCoreAttribute")]
+            [EndpointName("EndpointNameAttribute")]
+            class TestEndpointTypeWithBothEndpointNameAttribute
+            {
+            }
+
             [Test]
             [Ignore("this hasn't been implemented yet as far as i can tell")]
             public void when_endpointName_is_provided_via_configuration_it_should_have_second_priority()
@@ -162,10 +206,6 @@ namespace NServiceBus.Hosting.Tests
         {
         }
 
-        [EndpointName("EndpointNameFromAttribute")]
-        class TestEndpointTypeWithEndpointNameAttribute
-        {
-        }
     }
 }
 

--- a/src/NServiceBus.Hosting.Windows/EndpointNameAttribute.cs
+++ b/src/NServiceBus.Hosting.Windows/EndpointNameAttribute.cs
@@ -1,0 +1,30 @@
+﻿namespace NServiceBus.Hosting.Windows
+{
+    using System;
+
+    /// <summary>
+    /// Used to specify the name of the current endpoint.
+    /// Will be used as the name of the input queue as well.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class)]
+    public sealed class EndpointNameAttribute : Attribute
+    {
+        /// <summary>
+        /// Used to specify the name of the current endpoint.
+        /// Will be used as the name of the input queue as well.
+        /// </summary>
+        public EndpointNameAttribute(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentNullException("name");
+            }
+            Name = name;
+        }
+
+        /// <summary>
+        /// The name of the endpoint.
+        /// </summary>
+        public string Name { get; private set; }
+    }
+}

--- a/src/NServiceBus.Hosting.Windows/EndpointType.cs
+++ b/src/NServiceBus.Hosting.Windows/EndpointType.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.IO;
+    using System.Linq;
     using Arguments;
 
     /// <summary>
@@ -56,17 +57,25 @@
         {
             get
             {
-                var arr = type.GetCustomAttributes(typeof (EndpointNameAttribute), false);
-                if (arr.Length == 1)
+                var hostEndpointAttribute = (EndpointNameAttribute)type.GetCustomAttributes(typeof(EndpointNameAttribute), false)
+                    .FirstOrDefault();
+                var coreEndpointAttribute = (NServiceBus.EndpointNameAttribute)type.GetCustomAttributes(typeof(NServiceBus.EndpointNameAttribute), false)
+                    .FirstOrDefault();
+
+                if (hostEndpointAttribute != null && coreEndpointAttribute != null)
                 {
-                    return ((EndpointNameAttribute) arr[0]).Name;
+                    throw new Exception("Please either define a [NServiceBus.EndpointNameAttribute] or a [NServiceBus.Hosting.Windows.EndpointNameAttribute], but not both.");
                 }
-                
-                if (arguments.EndpointName != null)
+                if (hostEndpointAttribute != null)
                 {
-                    return arguments.EndpointName;
+                    return hostEndpointAttribute.Name;
                 }
-                return null;
+                if (coreEndpointAttribute != null)
+                {
+                    return coreEndpointAttribute.Name;
+                }
+
+                return arguments.EndpointName;
             }
         }
 

--- a/src/NServiceBus.Hosting.Windows/NServiceBus.Host.csproj
+++ b/src/NServiceBus.Hosting.Windows/NServiceBus.Host.csproj
@@ -54,7 +54,9 @@
     <ApplicationIcon>NServiceBus.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
-    <None Include="app.config" />
+    <None Include="app.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="FodyWeavers.xml">
       <SubType>Designer</SubType>
     </None>
@@ -103,6 +105,7 @@
     <Compile Include="..\NServiceBus.Hosting.Profiles\ProfileManager.cs">
       <Link>Profiles\ProfileManager.cs</Link>
     </Compile>
+    <Compile Include="EndpointNameAttribute.cs" />
     <Compile Include="EndpointType.cs" />
     <Compile Include="EndpointTypeDeterminer.cs" />
     <Compile Include="FileVersionRetriever.cs" />

--- a/src/NServiceBus.Hosting.Windows/NServiceBus.Host32.csproj
+++ b/src/NServiceBus.Hosting.Windows/NServiceBus.Host32.csproj
@@ -107,6 +107,7 @@
     <Compile Include="..\NServiceBus.Hosting.Profiles\ProfileManager.cs">
       <Link>Profiles\ProfileManager.cs</Link>
     </Compile>
+    <Compile Include="EndpointNameAttribute.cs" />
     <Compile Include="EndpointType.cs" />
     <Compile Include="EndpointTypeDeterminer.cs" />
     <Compile Include="FileVersionRetriever.cs" />


### PR DESCRIPTION
So that the host supports both the core attribute and the host
attribute. in prep for deprecating the core name attribute