### PR TITLE
IWantToRunWhenWhenEndpointStartsAndStop Blocking Warning

### DIFF
--- a/src/NServiceBus.Hosting.Tests/NServiceBus.Hosting.Tests.csproj
+++ b/src/NServiceBus.Hosting.Tests/NServiceBus.Hosting.Tests.csproj
@@ -43,6 +43,10 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Moq, Version=4.2.1510.2205, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\packages\Moq.4.2.1510.2205\lib\net40\Moq.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="NServiceBus.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
       <HintPath>..\packages\NServiceBus.6.0.0-unstable1725\lib\net452\NServiceBus.Core.dll</HintPath>
       <Private>True</Private>
@@ -72,6 +76,7 @@
     <Compile Include="MyEndpointConfig.cs" />
     <Compile Include="ProfileManagerTests.cs" />
     <Compile Include="StartablesAndStoppables\StartableAndStoppableRunnerTests.cs" />
+    <Compile Include="StartablesAndStoppables\StartableAndStoppableRunnerTimeoutTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NServiceBus.Hosting.Windows\NServiceBus.Host.csproj">

--- a/src/NServiceBus.Hosting.Tests/StartablesAndStoppables/StartableAndStoppableRunnerTimeoutTests.cs
+++ b/src/NServiceBus.Hosting.Tests/StartablesAndStoppables/StartableAndStoppableRunnerTimeoutTests.cs
@@ -1,0 +1,64 @@
+﻿namespace NServiceBus.Hosting.Tests
+{
+    using System;
+    using System.Threading.Tasks;
+    using Logging;
+    using Moq;
+    using NUnit.Framework;
+
+    public class StartableAndStoppableRunnerTimeoutTests
+    {
+        static TimeSpan TimeToWarn = TimeSpan.FromSeconds(1);
+        static TimeSpan TimeToWaitForTimeout = TimeToWarn.Add(TimeSpan.FromSeconds(2));
+
+        [Test]
+        public async Task Should_log_warning_on_long_start()
+        {
+            var mockLogger = await RunSlowStartableTest();
+
+            mockLogger.Verify(m => m.Warn(It.IsRegex(".+The endpoint will not start until this operation has completed.+")));
+        }
+
+        [Test]
+        public async Task Should_log_warning_on_long_stop()
+        {
+            var mockLogger = await RunSlowStartableTest();
+
+            mockLogger.Verify(m => m.Warn(It.IsRegex(".+The endpoint will not shut down.+")));
+        }
+
+        static async Task<Mock<ILog>> RunSlowStartableTest()
+        {
+            var startable = new BlockingLongRunningStartable();
+            var thingsToBeStarted = new IWantToRunWhenEndpointStartsAndStops[]
+            {
+                startable
+            };
+
+            var mockLogger = new Mock<ILog>();
+
+            var runner = new StartableAndStoppableRunner(thingsToBeStarted);
+
+            runner.LongRunningWarningTimeSpan = TimeToWarn;
+            StartableAndStoppableRunner.Log = mockLogger.Object;
+
+            await runner.Start(null);
+            await runner.Stop(null);
+
+            return mockLogger;
+        }
+
+        class BlockingLongRunningStartable : IWantToRunWhenEndpointStartsAndStops
+        {
+            public async Task Start(IMessageSession session)
+            {
+                await Task.Delay(TimeToWaitForTimeout);
+            }
+
+            public async Task Stop(IMessageSession session)
+            {
+                await Task.Delay(TimeToWaitForTimeout);
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Hosting.Tests/packages.config
+++ b/src/NServiceBus.Hosting.Tests/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Moq" version="4.2.1510.2205" targetFramework="net452" />
   <package id="NServiceBus" version="6.0.0-unstable1725" targetFramework="net452" />
   <package id="NUnit" version="2.6.4" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Add a timeout to warn users when their `IWantToRunWhenWhenEndpointStartsAndStop` implementation takes more than 2 minutes for Start or Stop.

Connects to https://github.com/Particular/NServiceBus/issues/3342