### PR TITLE
Add EndpointConfig.cs via nuget Content instead of install.ps1

### DIFF
--- a/packaging/nuget/nservicebus.host.nuspec
+++ b/packaging/nuget/nservicebus.host.nuspec
@@ -20,6 +20,7 @@
   </metadata>
   <files>
     <file src="..\..\binaries\NServiceBus.Host.???" target="lib\net452" />
-    <file src="..\..\packaging\nuget\nservicebus.host\*.*" target="tools" />
+    <file src="..\..\packaging\nuget\nservicebus.host\install.ps1" target="tools\net452" />
+    <file src="..\..\packaging\nuget\nservicebus.host\EndpointConfig.cs.pp" target="content\net452" />
   </files>
 </package>

--- a/packaging/nuget/nservicebus.host/EndpointConfig.cs.pp
+++ b/packaging/nuget/nservicebus.host/EndpointConfig.cs.pp
@@ -1,5 +1,5 @@
 
-namespace rootnamespace
+namespace $rootnamespace$
 {
     using NServiceBus;
 
@@ -11,7 +11,7 @@ namespace rootnamespace
             // Refer to the documentation for more details on specific options.
             endpointConfiguration.UsePersistence<PLEASE_SELECT_ONE>();
 
-            // NServiceBus will move messages that fail repeatedly to a separate "error" queue. We recommend 
+            // NServiceBus will move messages that fail repeatedly to a separate "error" queue. We recommend
             // that you start with a shared error queue for all your endpoints for easy integration with ServiceControl.
             endpointConfiguration.SendFailedMessagesTo("error");
 

--- a/packaging/nuget/nservicebus.host/install.ps1
+++ b/packaging/nuget/nservicebus.host/install.ps1
@@ -1,71 +1,18 @@
 param($installPath, $toolsPath, $package, $project)
 
 if(!$toolsPath){
-	$project = Get-Project
-}
-
-function Get-ConfigureThisEndpointClass($elem) {
-
-    if ($elem.IsCodeType -and ($elem.Kind -eq [EnvDTE.vsCMElement]::vsCMElementClass)) {
-        foreach ($e in $elem.ImplementedInterfaces) {
-            if ($e.FullName -eq "NServiceBus.IConfigureThisEndpoint") {
-                return $elem
-            }
-
-            return Get-ConfigureThisEndpointClass($e)
-
-        }
-    }
-    elseif ($elem.Kind -eq [EnvDTE.vsCMElement]::vsCMElementNamespace) {
-        foreach ($e in $elem.Members) {
-            $temp = Get-ConfigureThisEndpointClass($e)
-            if($temp -ne $null) {
-
-                return $temp
-            }
-        }
-    }
-
-    $null
-}
-
-function Test-HasConfigureThisEndpoint($project) {
-
-    foreach ($item in $project.ProjectItems) {
-		if ($projItem.Name -eq "EndpointConfig.cs") {
-			return $true
-		}
-
-		if (HasConfigureThisEndpoint($item)){
-			return $true
-		}
-    }
-
-    $false
-}
-
-function HasConfigureThisEndpoint($projItem) {
-	foreach ($codeElem in $projItem.FileCodeModel.CodeElements) {
-		$elem = Get-ConfigureThisEndpointClass($codeElem)
-		if($elem -ne $null) {
-			return $true
-		}
-	}
-
-	foreach ($item in $projItem.ProjectItems) {
-		return HasConfigureThisEndpoint($item)
-	}
+    $project = Get-Project
 }
 
 function Add-StartProgramIfNeeded {
-	[xml] $prjXml = Get-Content $project.FullName
-	foreach($PropertyGroup in $prjXml.project.ChildNodes)
-	{
-		if($PropertyGroup.StartAction -ne $null)
-		{
-			return
-		}
-	}
+    [xml] $prjXml = Get-Content $project.FullName
+    foreach($PropertyGroup in $prjXml.project.ChildNodes)
+    {
+        if($PropertyGroup.StartAction -ne $null)
+        {
+            return
+        }
+    }
 
     $exeName = "NServiceBus.Host"
 
@@ -76,39 +23,24 @@ function Add-StartProgramIfNeeded {
 
     $exeName += ".exe"
 
-	$propertyGroupElement = $prjXml.CreateElement("PropertyGroup", $prjXml.Project.GetAttribute("xmlns"));
-	$startActionElement = $prjXml.CreateElement("StartAction", $prjXml.Project.GetAttribute("xmlns"));
-	$propertyGroupElement.AppendChild($startActionElement) | Out-Null
-	$propertyGroupElement.StartAction = "Program"
-	$startProgramElement = $prjXml.CreateElement("StartProgram", $prjXml.Project.GetAttribute("xmlns"));
-	$propertyGroupElement.AppendChild($startProgramElement) | Out-Null
-	$propertyGroupElement.StartProgram = "`$(ProjectDir)`$(OutputPath)$exeName"
-	$prjXml.project.AppendChild($propertyGroupElement) | Out-Null
-	$writerSettings = new-object System.Xml.XmlWriterSettings
-	$writerSettings.OmitXmlDeclaration = $false
-	$writerSettings.NewLineOnAttributes = $false
-	$writerSettings.Indent = $true
-	$projectFilePath = Resolve-Path -Path $project.FullName
-	$writer = [System.Xml.XmlWriter]::Create($projectFilePath, $writerSettings)
-	$prjXml.WriteTo($writer)
-	$writer.Flush()
-	$writer.Close()
+    $propertyGroupElement = $prjXml.CreateElement("PropertyGroup", $prjXml.Project.GetAttribute("xmlns"));
+    $startActionElement = $prjXml.CreateElement("StartAction", $prjXml.Project.GetAttribute("xmlns"));
+    $propertyGroupElement.AppendChild($startActionElement) | Out-Null
+    $propertyGroupElement.StartAction = "Program"
+    $startProgramElement = $prjXml.CreateElement("StartProgram", $prjXml.Project.GetAttribute("xmlns"));
+    $propertyGroupElement.AppendChild($startProgramElement) | Out-Null
+    $propertyGroupElement.StartProgram = "`$(ProjectDir)`$(OutputPath)$exeName"
+    $prjXml.project.AppendChild($propertyGroupElement) | Out-Null
+    $writerSettings = new-object System.Xml.XmlWriterSettings
+    $writerSettings.OmitXmlDeclaration = $false
+    $writerSettings.NewLineOnAttributes = $false
+    $writerSettings.Indent = $true
+    $projectFilePath = Resolve-Path -Path $project.FullName
+    $writer = [System.Xml.XmlWriter]::Create($projectFilePath, $writerSettings)
+    $prjXml.WriteTo($writer)
+    $writer.Flush()
+    $writer.Close()
 }
-function Add-EndpointConfigIfRequired {
-	$foundConfigureThisEndpoint = Test-HasConfigureThisEndpoint($project)
-
-	if($foundConfigureThisEndpoint -eq $false) {
-		$namespace = $project.Properties.Item("DefaultNamespace").Value
-
-		$projectDir = [System.IO.Path]::GetDirectoryName($project.FullName)
-		$endpoingConfigPath = [System.IO.Path]::Combine( $projectDir, "EndpointConfig.cs")
-		Get-Content  "$installPath\Tools\EndpointConfig.cs" | ForEach-Object { $_ -replace "rootnamespace", $namespace } | Set-Content ($endpoingConfigPath)
-
-		$project.ProjectItems.AddFromFile( $endpoingConfigPath )
-	}
-}
-
-Add-EndpointConfigIfRequired
 
 $project.Save()
 

--- a/packaging/nuget/nservicebus.host32.nuspec
+++ b/packaging/nuget/nservicebus.host32.nuspec
@@ -20,6 +20,7 @@
   </metadata>
   <files>
     <file src="..\..\binaries\NServiceBus.Host32.???" target="lib\net452" />
-	<file src="..\..\packaging\nuget\nservicebus.host\*.*" target="tools" />
+    <file src="..\..\packaging\nuget\nservicebus.host\install.ps1" target="tools\net452" />
+    <file src="..\..\packaging\nuget\nservicebus.host\EndpointConfig.cs.pp" target="content\net452" />
   </files>
 </package>


### PR DESCRIPTION
connects to #68 

The powershell script in `install.ps1` that adds `EndpointConfig.cs` to the project was always adding the file, overwriting any existing file in the process.

This changes the nuget packages to use the Content section of nuget to add the file, which automatically correctly handles all of the selective adding/removing for us.