### PR TITLE
Async all the way up

### DIFF
--- a/src/NServiceBus.Hosting.ComponentTests/When_starting_and_stopping_host.cs
+++ b/src/NServiceBus.Hosting.ComponentTests/When_starting_and_stopping_host.cs
@@ -9,32 +9,32 @@
     public class When_starting_and_stopping_host
     {
         [Test]
-        public void Start_and_stop_are_called_for_scanned_type()
+        public async Task Start_and_stop_are_called_for_scanned_type()
         {
-            var context = RunHost();
+            var context = await RunHost();
 
             Assert.True(context.ScannedStartCalled);
             Assert.True(context.ScannedStopCalled);
         }
 
         [Test]
-        public void Start_and_stop_are_called_for_instance()
+        public async Task Start_and_stop_are_called_for_instance()
         {
-            var context = RunHost();
+            var context = await RunHost();
 
             Assert.True(context.InstanceStartCalled);
             Assert.True(context.InstanceStopCalled);
         }
 
         [Test]
-        public void Instance_is_registered_once()
+        public async Task Instance_is_registered_once()
         {
-            var context = RunHost();
+            var context = await RunHost();
 
             Assert.AreEqual(1, context.InstanceTimesRegistered);
         }
 
-        static IWantToRunContext RunHost()
+        static async Task<IWantToRunContext> RunHost()
         {
             var defaultProfiles = new List<Type>
             {
@@ -48,8 +48,8 @@
 
             var host = new GenericHost(configurer, args, defaultProfiles, GenericEndpointConfig.EndpointName);
 
-            host.Start();
-            host.Stop();
+            await host.Start();
+            await host.Stop();
 
             return context;
         }

--- a/src/NServiceBus.Hosting.Windows/GenericHost.cs
+++ b/src/NServiceBus.Hosting.Windows/GenericHost.cs
@@ -41,12 +41,12 @@ namespace NServiceBus
             profileManager = new ProfileManager(assembliesToScan, args, defaultProfiles);
         }
 
-        public void Start()
+        public async Task Start()
         {
             try
             {
-                var startableEndpoint = PerformConfiguration().GetAwaiter().GetResult();
-                endpoint = startableEndpoint.Start().GetAwaiter().GetResult();
+                var startableEndpoint = await PerformConfiguration().ConfigureAwait(false);
+                endpoint = await startableEndpoint.Start().ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -55,9 +55,12 @@ namespace NServiceBus
             }
         }
 
-        public void Stop()
+        public async Task Stop()
         {
-            endpoint?.Stop().GetAwaiter().GetResult();
+            if (endpoint != null)
+            {
+                await endpoint.Stop().ConfigureAwait(false);
+            }
         }
 
         /// <summary>

--- a/src/NServiceBus.Hosting.Windows/GenericHost.cs
+++ b/src/NServiceBus.Hosting.Windows/GenericHost.cs
@@ -66,10 +66,9 @@ namespace NServiceBus
         /// <summary>
         /// When installing as windows service (/install), run infrastructure installers
         /// </summary>
-        public void Install(string username)
+        public Task Install(string username)
         {
-            PerformConfiguration(builder => builder.EnableInstallers(username))
-                .Dispose();
+            return PerformConfiguration(builder => builder.EnableInstallers(username));
         }
 
         Task<IStartableEndpoint> PerformConfiguration(Action<EndpointConfiguration> moreConfiguration = null)

--- a/src/NServiceBus.Hosting.Windows/InstallWindowsHost.cs
+++ b/src/NServiceBus.Hosting.Windows/InstallWindowsHost.cs
@@ -28,7 +28,7 @@ namespace NServiceBus.Hosting.Windows
         /// <param name="username">Username passed in to host.</param>
         public void Install(string username)
         {
-            genericHost.Install(username);
+            genericHost.Install(username).GetAwaiter().GetResult();
         }
     }
 }

--- a/src/NServiceBus.Hosting.Windows/WindowsHost.cs
+++ b/src/NServiceBus.Hosting.Windows/WindowsHost.cs
@@ -26,7 +26,7 @@ namespace NServiceBus.Hosting.Windows
         /// </summary>
         public void Start()
         {
-            genericHost.Start();
+            genericHost.Start().GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -34,7 +34,7 @@ namespace NServiceBus.Hosting.Windows
         /// </summary>
         public void Stop()
         {
-            genericHost.Stop();
+            genericHost.Stop().GetAwaiter().GetResult();
         }
 
     }


### PR DESCRIPTION
Connects to https://github.com/Particular/NServiceBus.Host/issues/61

* GenericHost is async, synchronization happens one level up
* Fixed a bug in the install phase where the perform configuration call was not awaited but the returned Task was disposed

## Questions
* I stopped at the `WindowsHost` since this is a public type and I didn't want to break that interface, although I see no reasons why this type needs to be public.

@Particular/nservicebus-maintainers please review