### PR TITLE
[WIP] Advanced return endpoint instance

### DIFF
--- a/src/NServiceBus.Hosting.Tests/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Hosting.Tests/APIApprovals.Approve.approved.txt
@@ -23,12 +23,18 @@ namespace NServiceBus
         public EndpointSLAAttribute(string sla) { }
         public System.TimeSpan SLA { get; }
     }
+    [System.ObsoleteAttribute(". Will be treated as an error from version 8.0.0. Will be removed in version 9.0." +
+        "0.", false)]
     public interface IConfigureThisEndpoint
     {
         void Customize(NServiceBus.EndpointConfiguration configuration);
     }
     public interface Integration : NServiceBus.IProfile { }
     public interface IProfile { }
+    public interface IStartThisEndpoint
+    {
+        System.Threading.Tasks.Task<NServiceBus.IEndpointInstance> Start(string proposedEndpointName, System.Action<NServiceBus.EndpointConfiguration> applyHostConventions);
+    }
     public interface IWantTheListOfActiveProfiles
     {
         System.Collections.Generic.IEnumerable<System.Type> ActiveProfiles { get; set; }

--- a/src/NServiceBus.Hosting.Tests/GetEndpointConfigurationTypeTests.cs
+++ b/src/NServiceBus.Hosting.Tests/GetEndpointConfigurationTypeTests.cs
@@ -4,6 +4,7 @@ namespace EndpointTypeDeterminerTests
     using System.Collections.Generic;
     using System.Configuration;
     using System.Reflection;
+    using System.Threading.Tasks;
     using NServiceBus;
     using NServiceBus.Hosting.Helpers;
     using NServiceBus.Hosting.Windows;
@@ -73,11 +74,13 @@ namespace EndpointTypeDeterminerTests
         }
 
         //this will cause more than one config to be found when scanning and make the when_multiple_endpoint_types_found_via_assembly_scanning_it_should_blow_up test pass
-        class MyEndpointConfig2 : IConfigureThisEndpoint
+        class MyEndpointConfig2 : IStartThisEndpoint
         {
-            public void Customize(EndpointConfiguration configuration)
+            public Task<IEndpointInstance> Start(string proposedEndpointName, Action<EndpointConfiguration> applyHostConventions)
             {
-
+                var configuration = new EndpointConfiguration(proposedEndpointName);
+                applyHostConventions(configuration);
+                return Task.FromResult(default(IEndpointInstance));
             }
         }
     }

--- a/src/NServiceBus.Hosting.Tests/MyEndpointConfig.cs
+++ b/src/NServiceBus.Hosting.Tests/MyEndpointConfig.cs
@@ -1,13 +1,17 @@
 namespace EndpointTypeDeterminerTests
 {
+    using System;
+    using System.Threading.Tasks;
     using NServiceBus;
 
     //referenced from in app.config
-    class MyEndpointConfig : IConfigureThisEndpoint
+    class MyEndpointConfig : IStartThisEndpoint
     {
-        public void Customize(EndpointConfiguration configuration)
+        public Task<IEndpointInstance> Start(string proposedEndpointName, Action<EndpointConfiguration> applyHostConventions)
         {
-
+            var configuration = new EndpointConfiguration(proposedEndpointName);
+            applyHostConventions(configuration);
+            return Task.FromResult(default(IEndpointInstance));
         }
     }
 }

--- a/src/NServiceBus.Hosting.Windows/Arguments/HostArguments.cs
+++ b/src/NServiceBus.Hosting.Windows/Arguments/HostArguments.cs
@@ -68,7 +68,7 @@ namespace NServiceBus.Hosting.Windows.Arguments
                     },
                     {
                         "endpointConfigurationType=",
-                        "Specify the type implementing IConfigureThisEndpoint that should be used."
+                        "Specify the type implementing IStartThisEndpoint that should be used."
                         , s => { EndpointConfigurationType = s; }
                     },
                     {

--- a/src/NServiceBus.Hosting.Windows/Content/Help.txt
+++ b/src/NServiceBus.Hosting.Windows/Content/Help.txt
@@ -20,7 +20,7 @@ The default for the display name is the same value as the service name, and the 
 
 You can also specify the endpoint configuration type in the file NServiceBus.Host.exe.config. This file is optional.
 
-If you don't specify the endpoint configuration type either in the command-line or in the NServiceBus.Host.exe.config file, all the DLLs in the runtime directory will be scanned for a type that implements NServiceBus.IConfigureThisEndpoint.
+If you don't specify the endpoint configuration type either in the command-line or in the NServiceBus.Host.exe.config file, all the DLLs in the runtime directory will be scanned for a type that implements NServiceBus.IStartThisEndpoint.
 
 If you set the service name and sidebyside during installation you will need to specify them when uninstalling them as well, eg:
 

--- a/src/NServiceBus.Hosting.Windows/EndpointTypeDeterminer.cs
+++ b/src/NServiceBus.Hosting.Windows/EndpointTypeDeterminer.cs
@@ -14,7 +14,7 @@
     ///     The first eligible Type is returned, checking (in order):
     ///     Args (for windows hosted endpoints)
     ///     Configuration
-    ///     Assembly scanning for <see cref="IConfigureThisEndpoint" />
+    ///     Assembly scanning for <see cref="IStartThisEndpoint" />
     /// </remarks>
     class EndpointTypeDeterminer
     {
@@ -79,7 +79,7 @@
             }
 
             throw new InvalidOperationException("No endpoint configuration found in scanned assemblies. " +
-                                                "This usually happens when NServiceBus fails to load your assembly containing IConfigureThisEndpoint." +
+                                                "This usually happens when NServiceBus fails to load your assembly containing IStartThisEndpoint." +
                                                 " Try specifying the type explicitly in the NServiceBus.Host.exe.config using the appSetting key: EndpointConfigurationType, " +
                                                 "Scanned path: " + AppDomain.CurrentDomain.BaseDirectory);
         }
@@ -157,8 +157,8 @@
             var scannableAssemblies = assemblyScannerResults.Assemblies;
 
             return scannableAssemblies.SelectMany(assembly => assembly.GetTypes().Where(
-                t => typeof(IConfigureThisEndpoint).IsAssignableFrom(t)
-                     && t != typeof(IConfigureThisEndpoint)
+                t => typeof(IStartThisEndpoint).IsAssignableFrom(t)
+                     && t != typeof(IStartThisEndpoint)
                      && !t.IsAbstract));
         }
 

--- a/src/NServiceBus.Hosting.Windows/GenericHost.cs
+++ b/src/NServiceBus.Hosting.Windows/GenericHost.cs
@@ -12,7 +12,7 @@ namespace NServiceBus
 
     class GenericHost
     {
-        public GenericHost(IConfigureThisEndpoint specifier, string[] args, List<Type> defaultProfiles, string endpointName, IEnumerable<string> scannableAssembliesFullName = null)
+        public GenericHost(IStartThisEndpoint specifier, string[] args, List<Type> defaultProfiles, string endpointName, IEnumerable<string> scannableAssembliesFullName = null)
         {
             this.specifier = specifier;
 
@@ -45,8 +45,7 @@ namespace NServiceBus
         {
             try
             {
-                var startableEndpoint = await PerformConfiguration().ConfigureAwait(false);
-                endpoint = await startableEndpoint.Start().ConfigureAwait(false);
+                endpoint = await PerformConfiguration().ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -71,31 +70,31 @@ namespace NServiceBus
             return PerformConfiguration(builder => builder.EnableInstallers(username));
         }
 
-        Task<IStartableEndpoint> PerformConfiguration(Action<EndpointConfiguration> moreConfiguration = null)
+        Task<IEndpointInstance> PerformConfiguration(Action<EndpointConfiguration> moreConfiguration = null)
         {
-            var loggingConfigurers = profileManager.GetLoggingConfigurer();
-            foreach (var loggingConfigurer in loggingConfigurers)
+            //var loggingConfigurers = profileManager.GetLoggingConfigurer();
+            //foreach (var loggingConfigurer in loggingConfigurers)
+            //{
+            //    // TODO: What about this?
+            //    loggingConfigurer.Configure(specifier);
+            //}
+
+            return specifier.Start(endpointNameToUse, configuration =>
             {
-                loggingConfigurer.Configure(specifier);
-            }
+                SetSlaFromAttribute(configuration, specifier);
 
-            var configuration = new EndpointConfiguration(endpointNameToUse);
-            SetSlaFromAttribute(configuration, specifier);
+                configuration.DefineCriticalErrorAction(OnCriticalError);
 
-            configuration.DefineCriticalErrorAction(OnCriticalError);
+                moreConfiguration?.Invoke(configuration);
 
-            moreConfiguration?.Invoke(configuration);
-
-            specifier.Customize(configuration);
-            RoleManager.TweakConfigurationBuilder(specifier, configuration);
-            profileManager.ActivateProfileHandlers(configuration);
-
-            return Endpoint.Create(configuration);
+                RoleManager.TweakConfigurationBuilder(specifier, configuration);
+                profileManager.ActivateProfileHandlers(configuration);
+            });
         }
 
-        void SetSlaFromAttribute(EndpointConfiguration configuration, IConfigureThisEndpoint configureThisEndpoint)
+        void SetSlaFromAttribute(EndpointConfiguration configuration, IStartThisEndpoint startThisEndpoint)
         {
-            var endpointConfigurationType = configureThisEndpoint
+            var endpointConfigurationType = startThisEndpoint
                 .GetType();
             TimeSpan sla;
             if (TryGetSlaFromEndpointConfigType(endpointConfigurationType, out sla))
@@ -132,6 +131,6 @@ namespace NServiceBus
         IEndpointInstance endpoint;
         string endpointNameToUse;
         ProfileManager profileManager;
-        IConfigureThisEndpoint specifier;
+        IStartThisEndpoint specifier;
     }
 }

--- a/src/NServiceBus.Hosting.Windows/IConfigureThisEndpoint.cs
+++ b/src/NServiceBus.Hosting.Windows/IConfigureThisEndpoint.cs
@@ -1,8 +1,12 @@
 ﻿namespace NServiceBus
 {
+    using System;
+    using System.Threading.Tasks;
+
     /// <summary>
     /// Indicate that the implementing class will specify configuration.
     /// </summary>
+    [ObsoleteEx(Message = "")]
     public interface IConfigureThisEndpoint
     {
         /// <summary>
@@ -10,5 +14,18 @@
         /// </summary>
         /// <param name="configuration">Endpoint configuration builder.</param>
         void Customize(EndpointConfiguration configuration);
+    }
+
+    /// <summary>
+    /// Indicate that the implementing class will specify configuration.
+    /// </summary>
+    public interface IStartThisEndpoint
+    {
+        /// <summary>
+        /// Allows to override default settings.
+        /// </summary>
+        /// <param name="proposedEndpointName">The proposed endpoint name.</param>
+        /// <param name="applyHostConventions">Apply the host conventions.</param>
+        Task<IEndpointInstance> Start(string proposedEndpointName, Action<EndpointConfiguration> applyHostConventions);
     }
 }

--- a/src/NServiceBus.Hosting.Windows/InstallWindowsHost.cs
+++ b/src/NServiceBus.Hosting.Windows/InstallWindowsHost.cs
@@ -12,11 +12,11 @@ namespace NServiceBus.Hosting.Windows
 
         /// <summary>
         /// Accepts the type which will specify the users custom configuration.
-        /// This type should implement <see cref="IConfigureThisEndpoint"/>.
+        /// This type should implement <see cref="IStartThisEndpoint"/>.
         /// </summary>
         public InstallWindowsHost(Type endpointType, string[] args, string endpointName, IEnumerable<string> scannableAssembliesFullName)
         {
-            var specifier = (IConfigureThisEndpoint)Activator.CreateInstance(endpointType);
+            var specifier = (IStartThisEndpoint)Activator.CreateInstance(endpointType);
 
             genericHost = new GenericHost(specifier, args, new List<Type> { typeof(Production) }, endpointName, scannableAssembliesFullName);
 

--- a/src/NServiceBus.Hosting.Windows/Roles/RoleManager.cs
+++ b/src/NServiceBus.Hosting.Windows/Roles/RoleManager.cs
@@ -7,7 +7,7 @@
 
     class RoleManager
     {
-        public static void TweakConfigurationBuilder(IConfigureThisEndpoint specifier, EndpointConfiguration config)
+        public static void TweakConfigurationBuilder(IStartThisEndpoint specifier, EndpointConfiguration config)
         {
             // ReSharper disable once SuspiciousTypeConversion.Global
             if (specifier is AsA_Client)
@@ -26,7 +26,7 @@
             }
         }
 
-        static bool TryGetTransportDefinitionType(IConfigureThisEndpoint specifier, out Type transportDefinitionType)
+        static bool TryGetTransportDefinitionType(IStartThisEndpoint specifier, out Type transportDefinitionType)
         {
             var transportType= specifier.GetType()
                 .GetInterfaces()

--- a/src/NServiceBus.Hosting.Windows/WindowsHost.cs
+++ b/src/NServiceBus.Hosting.Windows/WindowsHost.cs
@@ -12,11 +12,11 @@ namespace NServiceBus.Hosting.Windows
 
         /// <summary>
         /// Accepts the type which will specify the users custom configuration.
-        /// This type should implement <see cref="IConfigureThisEndpoint"/>.
+        /// This type should implement <see cref="IStartThisEndpoint"/>.
         /// </summary>
         public WindowsHost(Type endpointType, string[] args, string endpointName, IEnumerable<string> scannableAssembliesFullName)
         {
-            var specifier = (IConfigureThisEndpoint)Activator.CreateInstance(endpointType);
+            var specifier = (IStartThisEndpoint)Activator.CreateInstance(endpointType);
 
             genericHost = new GenericHost(specifier, args, new List<Type> { typeof(Production) }, endpointName, scannableAssembliesFullName);
         }


### PR DESCRIPTION
Connects to https://github.com/Particular/PlatformDevelopment/issues/819

In order to hash out a PoA I quickly spiked two approaches to resolve https://github.com/Particular/PlatformDevelopment/issues/819

This approach introduces a new interface `IStartThisEndpoint` which replaces `IConfigureThisEndpoint`. The responsibility of the implementor of this interface would be to return an already started endpoint instance.
## Pros
- Even closer to custom hosting than #86 
- Convenience of host is still there
- Users can bind `IEndpointInstance` to their container without doing nasty rebindings on a potentially already sealed container.
- Solves also https://github.com/Particular/NServiceBus.Host/issues/82 since we introduce a completely new interface
- Users are in charge to create the endpoint configuration, they can use the proposed endpoint name or apply a custom one, solves also https://github.com/Particular/NServiceBus/issues/2477#issuecomment-218133249 // cc @dvdstelt 
- We could allow them to skip the `applyHostConvention` or make it mandatory
## Cons
- More responsibility pushed to the implementor (could also be argued as a good thing)
- Maybe a bit more complexity with the added delegate
