### PR TITLE
DefineEndpointName allows to override the host assigned endpoint name

### DIFF
--- a/src/NServiceBus.Hosting.Tests/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Hosting.Tests/APIApprovals.Approve.approved.txt
@@ -9,7 +9,7 @@ namespace NServiceBus
     public interface AsA_Server { }
     public class static EndpointConfigurationExtensions
     {
-        public static void RunWhenEndpointStartsAndStops(this NServiceBus.EndpointConfiguration configuration, NServiceBus.IWantToRunWhenEndpointStartsAndStops startableAndStoppable) { }
+        public static void DefineEndpointName(this NServiceBus.EndpointConfiguration configuration, string endpointName) { }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Class | System.AttributeTargets.All)]
     public sealed class EndpointNameAttribute : System.Attribute
@@ -22,6 +22,10 @@ namespace NServiceBus
     {
         public EndpointSLAAttribute(string sla) { }
         public System.TimeSpan SLA { get; }
+    }
+    public class static EndpointStartableAndStoppableExtensions
+    {
+        public static void RunWhenEndpointStartsAndStops(this NServiceBus.EndpointConfiguration configuration, NServiceBus.IWantToRunWhenEndpointStartsAndStops startableAndStoppable) { }
     }
     public interface IConfigureThisEndpoint
     {

--- a/src/NServiceBus.Hosting.Windows/EndpointConfigurationExtensions.cs
+++ b/src/NServiceBus.Hosting.Windows/EndpointConfigurationExtensions.cs
@@ -1,0 +1,20 @@
+﻿namespace NServiceBus
+{
+    using Configuration.AdvanceExtensibility;
+
+    /// <summary>
+    /// Extentions for <see cref="EndpointConfiguration"/>.
+    /// </summary>
+    public static class EndpointConfigurationExtensions
+    {
+        /// <summary>
+        /// Defines the endpoint name in code thus overriding the previously assigned endpoint name.
+        /// </summary>
+        /// <param name="configuration">The configuration.</param>
+        /// <param name="endpointName">The endpoint name to be used.</param>
+        public static void DefineEndpointName(this EndpointConfiguration configuration, string endpointName)
+        {
+            configuration.GetSettings().Set("NServiceBus.Routing.EndpointName", endpointName);
+        }
+    }
+}

--- a/src/NServiceBus.Hosting.Windows/NServiceBus.Host.csproj
+++ b/src/NServiceBus.Hosting.Windows/NServiceBus.Host.csproj
@@ -108,6 +108,7 @@
       <Link>Profiles\ProfileManager.cs</Link>
     </Compile>
     <Compile Include="EndpointNameAttribute.cs" />
+    <Compile Include="EndpointConfigurationExtensions.cs" />
     <Compile Include="EndpointSLAAttribute.cs" />
     <Compile Include="EndpointType.cs" />
     <Compile Include="EndpointTypeDeterminer.cs" />
@@ -117,7 +118,7 @@
     <Compile Include="Installers\WindowsInstaller.cs" />
     <Compile Include="InternalsVisibleTo.cs" />
     <Compile Include="Resharper.Annotations.g.cs" />
-    <Compile Include="StartableAndStoppable\EndpointConfigurationExtensions.cs" />
+    <Compile Include="StartableAndStoppable\EndpointStartableAndStoppableExtensions.cs" />
     <Compile Include="StartableAndStoppable\IWantToRunWhenEndpointStartsAndStops.cs" />
     <Compile Include="LoggingHandlers\IntegrationLoggingHandler.cs" />
     <Compile Include="LoggingHandlers\LiteLoggingHandler.cs" />

--- a/src/NServiceBus.Hosting.Windows/NServiceBus.Host32.csproj
+++ b/src/NServiceBus.Hosting.Windows/NServiceBus.Host32.csproj
@@ -110,6 +110,7 @@
       <Link>Profiles\ProfileManager.cs</Link>
     </Compile>
     <Compile Include="AssemblyInfo.cs" />
+    <Compile Include="EndpointConfigurationExtensions.cs" />
     <Compile Include="EndpointNameAttribute.cs" />
     <Compile Include="EndpointSLAAttribute.cs" />
     <Compile Include="EndpointType.cs" />
@@ -132,7 +133,7 @@
     <Compile Include="Resharper.Annotations.g.cs" />
     <Compile Include="Roles\RoleManager.cs" />
     <Compile Include="Roles\UsingTransport.cs" />
-    <Compile Include="StartableAndStoppable\EndpointConfigurationExtensions.cs" />
+    <Compile Include="StartableAndStoppable\EndpointStartableAndStoppableExtensions.cs" />
     <Compile Include="StartableAndStoppable\IWantToRunWhenEndpointStartsAndStops.cs" />
     <Compile Include="StartableAndStoppable\StartableAndStoppableFeature.cs" />
     <Compile Include="StartableAndStoppable\StartableAndStoppableRunner.cs" />

--- a/src/NServiceBus.Hosting.Windows/StartableAndStoppable/EndpointStartableAndStoppableExtensions.cs
+++ b/src/NServiceBus.Hosting.Windows/StartableAndStoppable/EndpointStartableAndStoppableExtensions.cs
@@ -6,7 +6,7 @@ namespace NServiceBus
     /// <summary>
     /// Extension methods for EndpointConfiguration
     /// </summary>
-    public static class EndpointConfigurationExtensions
+    public static class EndpointStartableAndStoppableExtensions
     {
         /// <summary>
         /// Register a specific instance of an IWantToRunWhenEndpointStartsAndStops implementation


### PR DESCRIPTION
Relates to https://github.com/Particular/NServiceBus.Host.AzureCloudService/issues/57

Re-enables the possibility override the endpoint name from code.

-  Called it `DefineEndpointName` because Core has an obsoleted `EndpointName` method on the `EndpointConfiguration` level.

Docs PR 

https://github.com/Particular/docs.particular.net/pull/1657

@Particular/nservicebus-maintainers please review and merge

