### PR TITLE
Use the types collections from scanner results instead

### DIFF
--- a/src/NServiceBus.Hosting.Windows/EndpointTypeDeterminer.cs
+++ b/src/NServiceBus.Hosting.Windows/EndpointTypeDeterminer.cs
@@ -154,12 +154,11 @@
         IEnumerable<Type> ScanAssembliesForEndpoints()
         {
             assemblyScannerResults = assemblyScanner.GetScannableAssemblies();
-            var scannableAssemblies = assemblyScannerResults.Assemblies;
-
-            return scannableAssemblies.SelectMany(assembly => assembly.GetTypes().Where(
+          
+            return assemblyScannerResults.Types.Where(
                 t => typeof(IConfigureThisEndpoint).IsAssignableFrom(t)
                      && t != typeof(IConfigureThisEndpoint)
-                     && !t.IsAbstract));
+                     && !t.IsAbstract);
         }
 
         readonly AssemblyScanner assemblyScanner;


### PR DESCRIPTION
Since partially scannable assemblies returned from the scanner means that we should not use .GetTypes

Fixes https://github.com/Particular/NServiceBus.Host/issues/115