### PR TITLE
Add exception to failfast when a critical error occurs

### DIFF
--- a/src/NServiceBus.Hosting.Windows/GenericHost.cs
+++ b/src/NServiceBus.Hosting.Windows/GenericHost.cs
@@ -126,7 +126,7 @@ namespace NServiceBus
                 await Task.Delay(10000).ConfigureAwait(false); // so that user can see on their screen the problem
             }
 
-            Environment.FailFast("The following critical error was encountered by NServiceBus:NServiceBus is shutting down.");
+            Environment.FailFast("The following critical error was encountered by NServiceBus:NServiceBus is shutting down.", context.Exception);
         }
 
         IEndpointInstance endpoint;


### PR DESCRIPTION
`Environment.FailFast` creates an entry in both the Event Log and the dump file. While we were putting text into those locations we did not include the exception information with it.

@Particular/nservicebus-maintainers for review