### PR TITLE
Process exit code not set when service fails to start/stop gracefully (v7)

### DIFF
--- a/src/NServiceBus.Hosting.Windows/GenericHost.cs
+++ b/src/NServiceBus.Hosting.Windows/GenericHost.cs
@@ -126,7 +126,7 @@ namespace NServiceBus
                 await Task.Delay(10000).ConfigureAwait(false); // so that user can see on their screen the problem
             }
 
-            Environment.FailFast("The following critical error was encountered by NServiceBus:NServiceBus is shutting down.");
+            Environment.FailFast("The following critical error was encountered by NServiceBus:NServiceBus is shutting down.", context.Exception);
         }
 
         IEndpointInstance endpoint;

--- a/src/NServiceBus.Hosting.Windows/WindowsHost.cs
+++ b/src/NServiceBus.Hosting.Windows/WindowsHost.cs
@@ -2,12 +2,14 @@ namespace NServiceBus.Hosting.Windows
 {
     using System;
     using System.Collections.Generic;
+    using Logging;
 
     /// <summary>
     /// A windows implementation of the NServiceBus hosting solution
     /// </summary>
     public class WindowsHost : MarshalByRefObject
     {
+        ILog Log = LogManager.GetLogger<WindowsHost>();
         GenericHost genericHost;
 
         /// <summary>
@@ -26,7 +28,15 @@ namespace NServiceBus.Hosting.Windows
         /// </summary>
         public void Start()
         {
-            genericHost.Start().GetAwaiter().GetResult();
+            try
+            {
+                genericHost.Start().GetAwaiter().GetResult();
+            }
+            catch (Exception ex)
+            {
+                Log.Fatal("Start failure", ex);
+                Environment.Exit(-1);
+            }
         }
 
         /// <summary>
@@ -34,8 +44,15 @@ namespace NServiceBus.Hosting.Windows
         /// </summary>
         public void Stop()
         {
-            genericHost.Stop().GetAwaiter().GetResult();
+            try
+            {
+                genericHost.Stop().GetAwaiter().GetResult();
+            }
+            catch (Exception ex)
+            {
+                Log.Fatal("Stop failure", ex);
+                Environment.Exit(-2);
+            }
         }
-
     }
 }


### PR DESCRIPTION
The host uses (old) version 0.8.0 of the Topshelf project which seems to incorrect set the exit code when an errors happens during start/stop. An error could be as described in #119.

```
Magnum.StateMachine.StateMachineException: Exception occurred in Topshelf.Internal.ServiceController`1[[NServiceBus.Hosting.Windows.WindowsHost, NServiceBus.Host, Version=7.0.0.0, Culture=neutral, 

--8<-----8<-----8<-----8<-----8<-----8<-----8<-----8<-----8<-----8<---

   at NServiceBus.Hosting.Windows.WindowsHost.Start() in C:\Build\src\NServiceBus.Hosting.Windows\WindowsHost.cs:line 30
   at Magnum.StateMachine.EventActionList`1.Execute(T stateMachine, Event event, Object parameter) in c:\Code\Topshelf\src\Topshelf\Internal\Hosts\ServiceHost.cs:line 0
   --- End of inner exception stack trace ---
   at Magnum.StateMachine.ExceptionActionDictionary`1.HandleException(T stateMachine, Event event, Object parameter, Exception exception) in c:\Code\Topshelf\src\Topshelf\Internal\Hosts\ServiceHost.cs:line 0
```

This PR is basically a workaround for the Topshelf error by calling `Environment.Exit(int)` ourselves. This results in the windows service to actually fail which results in Windows Service Recovery to kick in.