### PR TITLE
Defer logger creation to allow custom logging configuration

### DIFF
--- a/src/NServiceBus.Hosting.Windows/WindowsHost.cs
+++ b/src/NServiceBus.Hosting.Windows/WindowsHost.cs
@@ -33,7 +33,7 @@ namespace NServiceBus.Hosting.Windows
             }
             catch (Exception exception)
             {
-                var log = LogManager.GetLogger<WindowsHost>();
+                var log = LogManager.GetLogger<WindowsHost>(); // Defers logger creation to allow custom logging configuration
                 log.Fatal("Start failure", exception);
                 Environment.Exit(-1);
             }
@@ -50,7 +50,7 @@ namespace NServiceBus.Hosting.Windows
             }
             catch (Exception exception)
             {
-                var log = LogManager.GetLogger<WindowsHost>();
+                var log = LogManager.GetLogger<WindowsHost>(); // Defers logger creation to allow custom logging configuration
                 log.Fatal("Stop failure", exception);
                 Environment.Exit(-2);
             }

--- a/src/NServiceBus.Hosting.Windows/WindowsHost.cs
+++ b/src/NServiceBus.Hosting.Windows/WindowsHost.cs
@@ -9,7 +9,6 @@ namespace NServiceBus.Hosting.Windows
     /// </summary>
     public class WindowsHost : MarshalByRefObject
     {
-        ILog Log = LogManager.GetLogger<WindowsHost>();
         GenericHost genericHost;
 
         /// <summary>
@@ -32,9 +31,10 @@ namespace NServiceBus.Hosting.Windows
             {
                 genericHost.Start().GetAwaiter().GetResult();
             }
-            catch (Exception ex)
+            catch (Exception exception)
             {
-                Log.Fatal("Start failure", ex);
+                var log = LogManager.GetLogger<WindowsHost>();
+                log.Fatal("Start failure", exception);
                 Environment.Exit(-1);
             }
         }
@@ -48,9 +48,10 @@ namespace NServiceBus.Hosting.Windows
             {
                 genericHost.Stop().GetAwaiter().GetResult();
             }
-            catch (Exception ex)
+            catch (Exception exception)
             {
-                Log.Fatal("Stop failure", ex);
+                var log = LogManager.GetLogger<WindowsHost>();
+                log.Fatal("Stop failure", exception);
                 Environment.Exit(-2);
             }
         }


### PR DESCRIPTION
this change https://github.com/Particular/NServiceBus.Host/commit/c591c75f68b64156fdbabb2960c0b811e2353aaa

added the line `ILog Log = LogManager.GetLogger<WindowsHost>();`

This line will execute prior to the logging being configured by the user and result in a incorrect log log file created as described here https://groups.google.com/forum/#!topic/particularsoftware/7QK15QEMV4E

This PR defers the log creation until after the user has a chance to configure it