### PR TITLE
Make TestApprover immune to shadow copying

### DIFF
--- a/src/NServiceBus.Hosting.Tests/TestApprover.cs
+++ b/src/NServiceBus.Hosting.Tests/TestApprover.cs
@@ -3,6 +3,7 @@
     using System.IO;
     using ApprovalTests;
     using ApprovalTests.Namers;
+    using NUnit.Framework;
 
     static class TestApprover
     {
@@ -15,17 +16,7 @@
 
         class ApprovalNamer : UnitTestFrameworkNamer
         {
-            public ApprovalNamer()
-            {
-                var assemblyPath = GetType().Assembly.Location;
-                var assemblyDir = Path.GetDirectoryName(assemblyPath);
-
-                sourcePath = Path.Combine(assemblyDir, "..", "..", "..", "ApprovalFiles");
-            }
-
-            public override string SourcePath => sourcePath;
-
-            readonly string sourcePath;
+            public override string SourcePath { get; } = Path.Combine(TestContext.CurrentContext.TestDirectory, "..", "..", "..", "ApprovalFiles");
         }
     }
 }


### PR DESCRIPTION
Using TestContext.CurrentContext.TestDirectory lets TestApprover work even when the test assembly has been shadow copied.