### PR TITLE
Defer logger creation to allow custom logging configuration for Host 6.*

### DIFF
--- a/src/NServiceBus.Hosting.Windows/WindowsHost.cs
+++ b/src/NServiceBus.Hosting.Windows/WindowsHost.cs
@@ -9,7 +9,6 @@ namespace NServiceBus.Hosting.Windows
     /// </summary>
     public class WindowsHost : MarshalByRefObject
     {
-        ILog Log = LogManager.GetLogger<WindowsHost>();
         NServiceBus.GenericHost genericHost;
 
         /// <summary>
@@ -34,7 +33,9 @@ namespace NServiceBus.Hosting.Windows
             }
             catch (Exception ex)
             {
-                Log.Fatal("Start failure", ex);
+                var log = LogManager.GetLogger<WindowsHost>();  // Defers logger creation to allow custom logging configuration
+
+                log.Fatal("Start failure", ex);
                 Environment.Exit(-1);
             }
         }
@@ -50,10 +51,10 @@ namespace NServiceBus.Hosting.Windows
             }
             catch (Exception ex)
             {
-                Log.Fatal("Stop failure", ex);
+                var log = LogManager.GetLogger<WindowsHost>();  // Defers logger creation to allow custom logging configuration
+                log.Fatal("Stop failure", ex);
                 Environment.Exit(-2);
             }
         }
-
     }
 }


### PR DESCRIPTION
This PR ports back #129 to Host 6.*.

It has been reported that it affects users of Host 6.*. Also, according to our support policy, we've got 6m before killing this version.